### PR TITLE
Minor change in the wording in the comment that starts an empty applications.css file

### DIFF
--- a/bundles/tooling/org.eclipse.fx.ide.jdt.ui/src/org/eclipse/fx/ide/jdt/ui/internal/wizard/JavaFXProjectWizard.java
+++ b/bundles/tooling/org.eclipse.fx.ide.jdt.ui/src/org/eclipse/fx/ide/jdt/ui/internal/wizard/JavaFXProjectWizard.java
@@ -232,7 +232,7 @@ public class JavaFXProjectWizard extends NewElementWizard implements IExecutable
 
 				{
 					IFile cssFile = p.getProject().getWorkspace().getRoot().getFile(path.append("application.css"));
-					ByteArrayInputStream in = new ByteArrayInputStream("/* JavaFX CSS - Leave this comment until you have at least create one rule which uses -fx-Property */".getBytes());
+					ByteArrayInputStream in = new ByteArrayInputStream("/* JavaFX CSS - Leave this comment until you have created at least one rule which uses -fx-Property */".getBytes());
 					cssFile.create(in, IFile.FORCE|IFile.KEEP_HISTORY, null);
 					in.close();
 				}


### PR DESCRIPTION
I found the wording of the empty applications.css file created by the JavaFXProjectWizard.java slightly odd.  So I propose this minor change to use better words in this comment.